### PR TITLE
Fix macOS minimum version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ import PackageDescription
 let package = Package(
     name: "OneAxisGeometryReader",
     platforms: [
-        .macOS(.v10_14), .iOS(.v13), .watchOS(.v6), .tvOS(.v13)
+        .macOS(.v10_15), .iOS(.v13), .watchOS(.v6), .tvOS(.v13)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
SwiftUI is only available from macOS 10.15: https://developer.apple.com/documentation/swiftui/