### PR TITLE
Rename APIs for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ SwiftUI still handles this as much gracefully as it can: if the container view h
 ## A solution
 OneAxisGeometryReader attempts to solve this issue by only reading the geometry on a specific axis, enabling to break the cyclic size dependency on the other axis it doesn't read:
 ```swift
-HorizontalGeometryReader { width in
+HGeometryReader { width in
 VStack {
     HStack(spacing: 0) {
         Text("Hello world!")
@@ -76,6 +76,7 @@ VStack {
 With this code, you will get the right result:
 ![The right result](https://raw.githubusercontent.com/adtrevor/OneAxisGeometryReader/master/readme_ressources/horizontalgeometryreader.png)
 
+You can also use `VGeometryReader` for a vertical geometry reader.
 
 ## State of this package
 This is an experimental package that may break in the future when the internals of SwiftUI evolve.

--- a/Sources/OneAxisGeometryReader/Deprecated.swift
+++ b/Sources/OneAxisGeometryReader/Deprecated.swift
@@ -1,0 +1,5 @@
+@available(*, deprecated, renamed: "HGeometryReader")
+public typealias HorizontalGeometryReader = HGeometryReader
+
+@available(*, deprecated, renamed: "VGeometryReader")
+public typealias VerticalGeometryReader = VGeometryReader

--- a/Sources/OneAxisGeometryReader/HorizontalGeometryReader.swift
+++ b/Sources/OneAxisGeometryReader/HorizontalGeometryReader.swift
@@ -24,7 +24,7 @@ struct WidthReaderView : View {
     }
 }
 
-public struct HorizontalGeometryReader<Content: View> : View {
+public struct HGeometryReader<Content: View> : View {
     
     var content: (CGFloat)->Content
     @State private var width: CGFloat = 0

--- a/Sources/OneAxisGeometryReader/VerticalGeometryReader.swift
+++ b/Sources/OneAxisGeometryReader/VerticalGeometryReader.swift
@@ -24,7 +24,7 @@ struct HeightReaderView : View {
     }
 }
 
-public struct VerticalGeometryReader<Content: View> : View {
+public struct VGeometryReader<Content: View> : View {
     
     var content: (CGFloat)->Content
     @State private var height: CGFloat = 0


### PR DESCRIPTION
`VerticalGeometryReader` and `HorizontalGeometryReader` have been renamed to `VGeometryReader` and `HGeometryReader` for more concise names that also fit better with existing SwiftUI naming conventions.

Type-aliases (with a deprecation warning) have been created so that it doesn't break the API (there was no tagged version until now).

Closes #6
Closes #4
